### PR TITLE
SSLMutex deprecated in Apache 2.4

### DIFF
--- a/templates/apache-ssl.j2
+++ b/templates/apache-ssl.j2
@@ -39,7 +39,7 @@ SSLSessionCacheTimeout  300
 #   Semaphore:
 #   Configure the path to the mutual exclusion semaphore the
 #   SSL engine uses internally for inter-process synchronization.
-SSLMutex default
+Mutex default
 
 #   Pseudo Random Number Generator (PRNG):
 #   Configure one or more sources to seed the PRNG of the


### PR DESCRIPTION
Apache 2.4 fails to run if ``SSLMutex`` is set - this needs to be replaced by ``Mutex``