### PR TITLE
SSLEngine statement not on global scope

### DIFF
--- a/templates/apache-ssl.j2
+++ b/templates/apache-ssl.j2
@@ -93,7 +93,7 @@ Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains
 
 #   SSL Engine Switch:
 #   Enable/Disable SSL for this virtual host.
-SSLEngine on
+#SSLEngine on
 
 #   SSL Protocol support:
 # List the enable protocol levels with which clients will be able to


### PR DESCRIPTION
``SSLEngine on`` on global scope prevents Apache 2.4 from starting on CentOS 7. 

It works fine when this is set in the virtual host config.